### PR TITLE
fix: map builstats of edk packages to their name

### DIFF
--- a/criticalpath/__main__.py
+++ b/criticalpath/__main__.py
@@ -11,11 +11,18 @@ parser.add_argument('stats_dirs', nargs='+',
                     help='one or more buildstats directories')
 parser.add_argument('-t', '--target', help='find critical path up to target')
 parser.add_argument('-s', '--source', help='find critical path from source')
+parser.add_argument('--missing', action='store_true',
+                    help='print steps for which no stats could be found')
 
 
 def main(args):
     graph = load_graph(args.depfile)
     weights = load_weights(args.stats_dirs, graph)
+
+    if args.missing:
+        print_missing_stats(graph, weights)
+        return
+
     critical_path = criticalpath.find_critical_path(graph,
                                                     weights,
                                                     args.source,
@@ -33,6 +40,13 @@ def load_graph(filename):
 def load_weights(stats_dirs, graph):
     cache = criticalpath.BuildstatsCache(stats_dirs)
     return {node: cache.load_elapsed_time(node) for node in list(graph)}
+
+
+def print_missing_stats(graph, weights):
+    missing_stats = [node for node in list(graph)
+                     if weights[node] == 0]
+    for node in missing_stats:
+        print(node)
 
 
 if __name__ == "__main__":

--- a/criticalpath/buildstats.py
+++ b/criticalpath/buildstats.py
@@ -77,7 +77,7 @@ class BuildstatsCache:
 
 
 def _directory_to_package(directory):
-    match = re.match(r'(.*)-([0-9]|git).*', directory)
+    match = re.match(r'(.*)-([0-9]|git|edk).*', directory)
     return match.group(1) if match else None
 
 

--- a/tests/test_buildstats_cache.py
+++ b/tests/test_buildstats_cache.py
@@ -71,6 +71,22 @@ def test_load_elapsed_time_for_missing_statsfile():
     assert time == 0
 
 
+def test_load_elapsed_time_for_edk_package():
+    stub_filesystem = StubFilesystem({
+        "somedir": ["ovmf-edk2-stable201905-r0"]
+    }, {
+        "somedir/ovmf-edk2-stable201905-r0/do_compile": """Event: TaskStarted
+Started: 1572226085.36
+Elapsed time: 585.36 seconds
+Ended: 1572226615.15
+"""
+    })
+
+    buildstats_cache = BuildstatsCache(["somedir"], stub_filesystem)
+    time = buildstats_cache.load_elapsed_time("ovmf.do_compile")
+    assert time == 585.36
+
+
 class StubFilesystem:
     def __init__(self, dir_map, file_map):
         self.dir_map = dir_map


### PR DESCRIPTION
This PR makes the buildstats of packages of the form `package-name-edk2-xxx-r0` available as weights in the graph.